### PR TITLE
Security, timer-leak, and correctness fixes (ported from fork review)

### DIFF
--- a/lib/cloudflare.js
+++ b/lib/cloudflare.js
@@ -1452,8 +1452,11 @@ async function handleEmbeddedIframeChallenge(page, forceDebug = false) {
       }
     }
 
-    // Reuse existing completion check pattern with error handling
+    // Reuse existing completion check pattern with error handling. Capture the
+    // race-timeout timer and clear it in .finally() so it doesn't leak when
+    // waitForFunction wins the race (the common, fast path).
     try {
+      let _cfT;
       await Promise.race([
         page.waitForFunction(
           () => {
@@ -1461,13 +1464,13 @@ async function handleEmbeddedIframeChallenge(page, forceDebug = false) {
             const hasResponse = responseInput && responseInput.value && responseInput.value.length > 0;
             const hasClearance = document.cookie.includes('cf_clearance');
             const noChallenge = !document.body.textContent.includes('Verify you are human');
-            
+
             return hasResponse || hasClearance || noChallenge;
           },
           { timeout: TIMEOUTS.TURNSTILE_COMPLETION }
         ),
-        new Promise((_, reject) => setTimeout(() => reject(new Error('Completion check timeout')), TIMEOUTS.TURNSTILE_COMPLETION_BUFFER))
-      ]);
+        new Promise((_, reject) => { _cfT = setTimeout(() => reject(new Error('Completion check timeout')), TIMEOUTS.TURNSTILE_COMPLETION_BUFFER); })
+      ]).finally(() => clearTimeout(_cfT));
 
       result.success = true;
       if (forceDebug) console.log(formatLogMessage('debug', `${CLOUDFLARE_TAG} Embedded iframe challenge completed`));
@@ -1573,10 +1576,11 @@ async function handleTurnstileChallenge(page, forceDebug = false) {
     let turnstileFrame = null;
     for (const selector of turnstileSelectors) {
       try {
+        let _cfT;
         await Promise.race([
           page.waitForSelector(selector, { timeout: FAST_TIMEOUTS.SELECTOR_WAIT }),
-          new Promise((_, reject) => setTimeout(() => reject(new Error('Selector timeout')), FAST_TIMEOUTS.SELECTOR_WAIT + 500))
-        ]);
+          new Promise((_, reject) => { _cfT = setTimeout(() => reject(new Error('Selector timeout')), FAST_TIMEOUTS.SELECTOR_WAIT + 500); })
+        ]).finally(() => clearTimeout(_cfT));
         
         const frames = await page.frames();
         turnstileFrame = frames.find(frame => 
@@ -1621,6 +1625,7 @@ async function handleTurnstileChallenge(page, forceDebug = false) {
       }
       
       // Wait for Turnstile completion with reduced timeout
+      let _cfT2;
       await Promise.race([
         page.waitForFunction(
           () => {
@@ -1629,8 +1634,8 @@ async function handleTurnstileChallenge(page, forceDebug = false) {
           },
           { timeout: TIMEOUTS.TURNSTILE_COMPLETION }
         ),
-        new Promise((_, reject) => setTimeout(() => reject(new Error('Turnstile completion timeout')), TIMEOUTS.TURNSTILE_COMPLETION_BUFFER))
-      ]);
+        new Promise((_, reject) => { _cfT2 = setTimeout(() => reject(new Error('Turnstile completion timeout')), TIMEOUTS.TURNSTILE_COMPLETION_BUFFER); })
+      ]).finally(() => clearTimeout(_cfT2));
       
       if (forceDebug) console.log(formatLogMessage('debug', `${CLOUDFLARE_TAG} Turnstile response token generated successfully`));
       result.success = true;
@@ -1646,10 +1651,11 @@ async function handleTurnstileChallenge(page, forceDebug = false) {
       
       for (const selector of containerSelectors) {
         try {
+          let _cfT;
           await Promise.race([
             page.waitForSelector(selector, { timeout: FAST_TIMEOUTS.SELECTOR_WAIT }),
-            new Promise((_, reject) => setTimeout(() => reject(new Error('Container timeout')), FAST_TIMEOUTS.SELECTOR_WAIT + 500))
-          ]);
+            new Promise((_, reject) => { _cfT = setTimeout(() => reject(new Error('Container timeout')), FAST_TIMEOUTS.SELECTOR_WAIT + 500); })
+          ]).finally(() => clearTimeout(_cfT));
           
           await fastTimeout(FAST_TIMEOUTS.ELEMENT_INTERACTION_DELAY);
           await page.click(selector);
@@ -1712,10 +1718,11 @@ async function handleLegacyCheckbox(page, forceDebug = false) {
 
     for (const selector of legacySelectors) {
       try {
+        let _cfT;
         await Promise.race([
           page.waitForSelector(selector, { timeout: FAST_TIMEOUTS.SELECTOR_WAIT }),
-          new Promise((_, reject) => setTimeout(() => reject(new Error('Legacy selector timeout')), FAST_TIMEOUTS.SELECTOR_WAIT + 500))
-        ]);
+          new Promise((_, reject) => { _cfT = setTimeout(() => reject(new Error('Legacy selector timeout')), FAST_TIMEOUTS.SELECTOR_WAIT + 500); })
+        ]).finally(() => clearTimeout(_cfT));
         
         const checkbox = await page.$(selector);
         if (checkbox) {

--- a/lib/curl.js
+++ b/lib/curl.js
@@ -61,6 +61,9 @@ async function downloadWithCurl(url, userAgent = '', options = {}) {
   ];
 
   if (followRedirects) curlArgs.push('-L');
+  // Restrict redirect targets to http/https so a redirect can't hop to
+  // file://, gopher://, dict://, etc. (SSRF / local-file read via redirect).
+  curlArgs.push('--proto-redir', '=http,https');
   if (userAgent) curlArgs.push('-H', `User-Agent: ${userAgent}`);
 
   curlArgs.push(
@@ -76,6 +79,9 @@ async function downloadWithCurl(url, userAgent = '', options = {}) {
   );
 
   Object.entries(customHeaders).forEach(([key, value]) => {
+    // Drop any header whose key/value carries CR/LF — prevents header injection
+    // (splitting extra headers/request lines into the -H value).
+    if (/[\r\n]/.test(key) || /[\r\n]/.test(String(value))) return;
     curlArgs.push('-H', `${key}: ${value}`);
   });
   // '--' end-of-options marker before the URL — defense in depth. Today

--- a/lib/grep.js
+++ b/lib/grep.js
@@ -155,6 +155,8 @@ async function downloadAndGrep(url, searchPatterns, userAgent = '', grepOptions 
     '--fail-with-body',
     '--compressed'
   ];
+  // Restrict redirect targets to http/https (SSRF / local-file read via redirect).
+  curlArgs.push('--proto-redir', '=http,https');
   if (userAgent) curlArgs.push('-H', `User-Agent: ${userAgent}`);
   curlArgs.push(
     '-H', 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',

--- a/lib/ignore_similar.js
+++ b/lib/ignore_similar.js
@@ -135,8 +135,9 @@ function shouldIgnoreSimilarDomain(newDomain, existingDomains, options = {}) {
     return { shouldIgnore: false, reason: 'could not extract base domain' };
   }
   
-  // KEEP original guard exactly as-is: Array.from handles undefined/null/objects safely
-  const domainsArray = Array.isArray(existingDomains) ? existingDomains : Array.from(existingDomains);
+  // Null/undefined guard first — Array.from(undefined) throws (the previous
+  // "handles undefined safely" comment was wrong).
+  const domainsArray = existingDomains == null ? [] : Array.isArray(existingDomains) ? existingDomains : Array.from(existingDomains);
   
   for (const existingDomain of domainsArray) {
     if (!existingDomain || existingDomain === newDomain) {

--- a/lib/interaction.js
+++ b/lib/interaction.js
@@ -404,9 +404,16 @@ function generateRandomCoordinates(maxX = DEFAULT_VIEWPORT.WIDTH, maxY = DEFAULT
       ++attempts < 50
     );
   } else {
-    // Standard random coordinates
-    x = Math.floor(Math.random() * (maxX - 2 * marginX)) + marginX;
-    y = Math.floor(Math.random() * (maxY - 2 * marginY)) + marginY;
+    // Standard random coordinates. Guard against a viewport smaller than the
+    // margins (rangeX/rangeY <= 0) — Math.random()*negative yields negative /
+    // out-of-bounds coords; fall back to the viewport centre.
+    const rangeX = maxX - 2 * marginX;
+    const rangeY = maxY - 2 * marginY;
+    if (rangeX <= 0 || rangeY <= 0) {
+      return { x: Math.floor(maxX / 2), y: Math.floor(maxY / 2) };
+    }
+    x = Math.floor(Math.random() * rangeX) + marginX;
+    y = Math.floor(Math.random() * rangeY) + marginY;
   }
 
   return { x, y };

--- a/lib/openvpn_vpn.js
+++ b/lib/openvpn_vpn.js
@@ -11,9 +11,22 @@
 const { execSync, spawn, spawnSync } = require('child_process');
 const crypto = require('crypto');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { formatLogMessage, messageColors } = require('./colorize');
 const OPENVPN_TAG = messageColors.processing('[openvpn]');
+
+// OpenVPN directives that can run arbitrary code as root (openvpn runs under
+// sudo) — never allowed via extra_args. NOTE: this guards extra_args only; a
+// hostile .ovpn config file (config/config_inline) can still carry these
+// directives, so trust the config source.
+const BLOCKED_EXTRA_ARGS = [
+  '--script-security', '--up', '--down', '--tls-verify', '--plugin',
+  '--route-up', '--ipchange', '--auth-user-pass-verify', '--auth-user-pass'
+];
+// connectionName is interpolated into a `pkill -f` regex; constrain it so it
+// can't broaden the pattern (`.*`) or match unrelated processes.
+const CONN_NAME_RE = /^[a-zA-Z0-9_.-]{1,64}$/;
 
 /**
  * Fetch external IP address through the active tunnel
@@ -353,9 +366,24 @@ function buildArgs(configPath, vpnConfig, connectionName, logPath) {
     args.push('--auth-user-pass', vpnConfig._authFilePath);
   }
 
-  // Extra args from config
+  // Extra args from config — filtered against BLOCKED_EXTRA_ARGS (root code-exec
+  // directives). A dropped flag's bare value (if space-separated) passes through
+  // harmlessly; openvpn ignores/errors on an orphan value.
   if (vpnConfig.extra_args && Array.isArray(vpnConfig.extra_args)) {
-    args.push(...vpnConfig.extra_args);
+    const safeArgs = [];
+    const droppedArgs = [];
+    for (const arg of vpnConfig.extra_args) {
+      const flagPart = String(arg).split('=')[0];
+      if (BLOCKED_EXTRA_ARGS.some(b => flagPart === b || String(arg).startsWith(b + '='))) {
+        droppedArgs.push(arg);
+      } else {
+        safeArgs.push(arg);
+      }
+    }
+    if (droppedArgs.length > 0) {
+      console.log(formatLogMessage('warn', `${OPENVPN_TAG} extra_args: dropped disallowed flags: ${droppedArgs.map(a => JSON.stringify(a)).join(', ')}`));
+    }
+    args.push(...safeArgs);
   }
 
   // WSL2-specific: force tun device type if needed
@@ -385,12 +413,15 @@ async function startConnection(configPath, vpnConfig, forceDebug = false) {
   }
 
   // Kill any stale processes from a previous run using this config.
-  // spawnSync with arg array (no shell) — connectionName flows from
-  // user config (vpnConfig.name). Naive shell interpolation here was
-  // vulnerable to '`; rm -rf ~; #' style injection.
-  const pkillRes = spawnSync('sudo', ['pkill', '-TERM', '-f', `openvpn.*${connectionName}`], {
-    encoding: 'utf8', timeout: 3000
-  });
+  // spawnSync with arg array (no shell) blocks shell injection; CONN_NAME_RE
+  // additionally stops a crafted name from broadening the `-f` regex (e.g. a
+  // bare `.*` matching every openvpn process). Skip the pkill if it fails.
+  if (!CONN_NAME_RE.test(connectionName)) {
+    console.log(formatLogMessage('warn', `${OPENVPN_TAG} startConnection: unsafe connectionName ${JSON.stringify(connectionName)}, skipping stale-process pkill`));
+  }
+  const pkillRes = CONN_NAME_RE.test(connectionName)
+    ? spawnSync('sudo', ['pkill', '-TERM', '-f', `openvpn.*${connectionName}`], { encoding: 'utf8', timeout: 3000 })
+    : { status: -1 };
   // Only sleep if pkill actually matched + killed something (status 0).
   // pkill exits 1 when no processes match — pre-execSync code threw on
   // non-zero and the surrounding try/catch swallowed it, so the sleep
@@ -408,8 +439,10 @@ async function startConnection(configPath, vpnConfig, forceDebug = false) {
   // Clean stale log
   try { fs.unlinkSync(logPath); } catch {}
 
-  // Pre-create log file writable by all so sudo openvpn can write and user can read
-  try { fs.writeFileSync(logPath, '', { mode: 0o666 }); } catch {}
+  // Pre-create the log 0o600 (owner-only). Created by this (user) process, so
+  // the user reads it; root openvpn bypasses perms to append. 0o666 let any
+  // local user read/tamper with the VPN log (poisoning/info-leak).
+  try { fs.writeFileSync(logPath, '', { mode: 0o600 }); } catch {}
 
   const args = buildArgs(configPath, vpnConfig, connectionName, logPath);
 
@@ -485,18 +518,22 @@ function stopConnection(connectionName, forceDebug = false) {
   }
 
   try {
-    // Find the actual openvpn PID (child of sudo) and kill it.
-    // spawnSync with arg array — connectionName from user config, naive
-    // shell interpolation was vulnerable to ';rm -rf ~' style injection.
-    spawnSync('sudo', ['pkill', '-TERM', '-f', `openvpn.*${connectionName}`], {
-      encoding: 'utf8', timeout: 3000
-    });
-
-    const killed = waitForProcessExit(info.pid, 5000);
-    if (!killed) {
-      spawnSync('sudo', ['pkill', '-9', '-f', `openvpn.*${connectionName}`], {
+    // Find the actual openvpn PID (child of sudo) and kill it. spawnSync arg
+    // array blocks shell injection; CONN_NAME_RE stops a crafted name from
+    // broadening the `-f` regex to match unrelated processes.
+    if (!CONN_NAME_RE.test(connectionName)) {
+      console.log(formatLogMessage('warn', `${OPENVPN_TAG} stopConnection: unsafe connectionName ${JSON.stringify(connectionName)}, skipping pkill`));
+    } else {
+      spawnSync('sudo', ['pkill', '-TERM', '-f', `openvpn.*${connectionName}`], {
         encoding: 'utf8', timeout: 3000
       });
+
+      const killed = waitForProcessExit(info.pid, 5000);
+      if (!killed) {
+        spawnSync('sudo', ['pkill', '-9', '-f', `openvpn.*${connectionName}`], {
+          encoding: 'utf8', timeout: 3000
+        });
+      }
     }
   } catch (killErr) {
     // Process may already be dead
@@ -666,6 +703,10 @@ function normalizeOvpnConfig(ovpnConfig) {
     return null;
   }
 
+  // Verbosity flows into `--verb <n>`; constrain to a single digit 1-6 so a
+  // crafted value can't smuggle another token onto the openvpn command line.
+  const rawVerbosity = String(ovpnConfig.verbosity || '3');
+
   return {
     config: ovpnConfig.config || null,
     config_inline: ovpnConfig.config_inline || null,
@@ -679,7 +720,7 @@ function normalizeOvpnConfig(ovpnConfig) {
     max_retries: ovpnConfig.max_retries || 2,
     connect_timeout: ovpnConfig.connect_timeout || DEFAULT_CONNECT_TIMEOUT,
     extra_args: ovpnConfig.extra_args || null,
-    verbosity: ovpnConfig.verbosity || '3'
+    verbosity: /^[1-6]$/.test(rawVerbosity) ? rawVerbosity : '3'
   };
 }
 
@@ -749,9 +790,20 @@ function validateOvpnConfig(ovpnConfig) {
   if (ovpnConfig.username && !ovpnConfig.password) {
     result.warnings.push('Username provided without password');
   }
-  if (ovpnConfig.auth_file && !fs.existsSync(ovpnConfig.auth_file)) {
-    result.isValid = false;
-    result.errors.push(`Auth file not found: ${ovpnConfig.auth_file}`);
+  if (ovpnConfig.auth_file) {
+    if (!fs.existsSync(ovpnConfig.auth_file)) {
+      result.isValid = false;
+      result.errors.push(`Auth file not found: ${ovpnConfig.auth_file}`);
+    } else {
+      // openvpn reads this as root — confine it to the project dir or the system
+      // temp dir so a config can't point --auth-user-pass at /etc/shadow etc.
+      const resolvedAuthFile = path.resolve(ovpnConfig.auth_file);
+      const allowedRoots = [path.resolve(process.cwd()), path.resolve(os.tmpdir())];
+      if (!allowedRoots.some(root => resolvedAuthFile === root || resolvedAuthFile.startsWith(root + path.sep))) {
+        result.isValid = false;
+        result.errors.push('Auth file must be within the project directory or system temp dir');
+      }
+    }
   }
 
   // Privilege check

--- a/lib/redirect.js
+++ b/lib/redirect.js
@@ -13,6 +13,9 @@
  */
 async function navigateWithRedirectHandling(page, currentUrl, siteConfig, gotoOptions = {}, forceDebug = false, formatLogMessage) {
   const redirectChain = [currentUrl];
+  // Parallel Set for O(1) membership checks — the array below was scanned with
+  // .includes() (O(n)) on every candidate hop. Kept in sync at each push.
+  const redirectChainSet = new Set([currentUrl]);
   let finalUrl = currentUrl;
   let redirected = false;
   // Hoisted so they're in scope at the return outside the try block below.
@@ -34,7 +37,7 @@ async function navigateWithRedirectHandling(page, currentUrl, siteConfig, gotoOp
       // redirect chain produces bogus entries like
       // "chrome-error://chromewebdata/" that downstream consumers
       // (redirectDomains, logs) treat as a real intermediate hop.
-      if (frameUrl && frameUrl !== 'about:blank' && !frameUrl.startsWith('chrome-error://') && !redirectChain.includes(frameUrl)) {
+      if (frameUrl && frameUrl !== 'about:blank' && !frameUrl.startsWith('chrome-error://') && !redirectChainSet.has(frameUrl)) {
         // Check redirect limit before adding
         if (redirectChain.length >= maxRedirects) {
           if (forceDebug) {
@@ -43,6 +46,7 @@ async function navigateWithRedirectHandling(page, currentUrl, siteConfig, gotoOp
           return; // Stop processing more redirects
         }
         redirectChain.push(frameUrl);
+        redirectChainSet.add(frameUrl);
         finalUrl = frameUrl;
         redirected = true;
         
@@ -203,7 +207,7 @@ async function navigateWithRedirectHandling(page, currentUrl, siteConfig, gotoOp
       } else {
         finalUrl = response.url();
         redirected = true;
-        if (!redirectChain.includes(finalUrl)) redirectChain.push(finalUrl);
+        if (!redirectChainSet.has(finalUrl)) { redirectChain.push(finalUrl); redirectChainSet.add(finalUrl); }
       }
       if (forceDebug) {
         console.log(formatLogMessage('debug', `HTTP redirect detected: ${currentUrl} -> ${finalUrl}`));
@@ -236,7 +240,7 @@ async function navigateWithRedirectHandling(page, currentUrl, siteConfig, gotoOp
         // Skip chrome-error://* — it's Puppeteer's landing page on DNS/connection
         // failure and adding it to the chain produces bogus intermediate hops.
         const currentPageUrl = page.url();
-        if (currentPageUrl && currentPageUrl !== finalUrl && !currentPageUrl.startsWith('chrome-error://') && !redirectChain.includes(currentPageUrl)) {
+        if (currentPageUrl && currentPageUrl !== finalUrl && !currentPageUrl.startsWith('chrome-error://') && !redirectChainSet.has(currentPageUrl)) {
           // Check redirect limit before adding
           if (redirectChain.length >= maxRedirects) {
             if (forceDebug) {
@@ -245,6 +249,7 @@ async function navigateWithRedirectHandling(page, currentUrl, siteConfig, gotoOp
             break; // Stop processing more redirects
           }
           redirectChain.push(currentPageUrl);
+          redirectChainSet.add(currentPageUrl);
           finalUrl = currentPageUrl;
           redirected = true;
           
@@ -299,8 +304,9 @@ async function navigateWithRedirectHandling(page, currentUrl, siteConfig, gotoOp
       } else {
         finalUrl = finalPageUrl;
         redirected = true;
-        if (!redirectChain.includes(finalUrl)) {
+        if (!redirectChainSet.has(finalUrl)) {
           redirectChain.push(finalUrl);
+          redirectChainSet.add(finalUrl);
         }
       }
     }

--- a/lib/searchstring.js
+++ b/lib/searchstring.js
@@ -228,6 +228,11 @@ function searchContent(content, searchStrings, searchStringsAnd = [], contentTyp
   return { found: false, matchedString: null, logicType: validSearchStrings.length > 0 ? 'OR' : 'NONE' };
 }
 
+// Text-ish content types to analyze — precompiled ^-anchored regex (equivalent
+// to the old array's .some(startsWith), but one test() instead of an O(n) scan
+// per response). `+`/`.` in the media types are escaped.
+const CONTENT_TYPE_RE = /^(text\/|application\/json|application\/javascript|application\/xml|application\/x-javascript|application\/soap\+xml|application\/rss\+xml|application\/atom\+xml|application\/xhtml\+xml|application\/ld\+json|application\/manifest\+json|application\/feed\+xml|application\/vnd\.api\+json|application\/hal\+json|application\/problem\+json)/;
+
 /**
  * Determines if a content type should be analyzed for search strings
  * @param {string} contentType - The response content-type header
@@ -238,26 +243,8 @@ function shouldAnalyzeContentType(contentType) {
 
   // Normalize content type (remove charset and other parameters)
   const normalizedType = contentType.toLowerCase().split(';')[0].trim();
-  
-  const textTypes = [
-    'text/',                    // text/html, text/plain, text/xml, etc.
-    'application/json',
-    'application/javascript',
-    'application/xml',          // Standard XML
-    'application/x-javascript',
-    'application/soap+xml',     // SOAP XML
-    'application/rss+xml',      // RSS feeds
-    'application/atom+xml',     // Atom feeds
-    'application/xhtml+xml',    // XHTML
-    'application/ld+json',      // JSON-LD structured data
-    'application/manifest+json', // Web App Manifest
-    'application/feed+xml',     // Generic XML feeds
-    'application/vnd.api+json', // JSON API specification
-    'application/hal+json',     // HAL (Hypertext Application Language)
-    'application/problem+json'  // Problem Details for HTTP APIs
-  ];
-  
-  return textTypes.some(type => normalizedType.startsWith(type));
+
+  return CONTENT_TYPE_RE.test(normalizedType);
 }
 
 /**

--- a/lib/smart-cache.js
+++ b/lib/smart-cache.js
@@ -1069,7 +1069,9 @@ class SmartCache {
     
     const cacheDir = this.options.persistencePath;
     const cacheFile = path.join(cacheDir, 'smart-cache.json');
-    const tmpFile = cacheFile + '.tmp';
+    // pid-suffixed temp so two concurrent processes don't clobber each other's
+    // partial write before the atomic rename (project convention, see CLAUDE.md).
+    const tmpFile = cacheFile + '.' + process.pid + '.tmp';
     
     try {
       // recursive:true is a no-op if dir exists -- no need for existsSync check
@@ -1084,7 +1086,7 @@ class SmartCache {
       
       // Async write to temp file, then atomic rename (no pretty-print -- saves ~30% serialization time)
       const jsonStr = JSON.stringify(data);
-      fs.writeFile(tmpFile, jsonStr, (writeErr) => {
+      fs.writeFile(tmpFile, jsonStr, { mode: 0o600 }, (writeErr) => {
         if (writeErr) {
           if (this._debug) {
             console.log(formatLogMessage('debug', 

--- a/nwss.js
+++ b/nwss.js
@@ -293,8 +293,12 @@ if (fs.existsSync(NWSSCONFIG_PATH)) {
           : settings[key.replace(/-/g, '_')] !== undefined ? settings[key.replace(/-/g, '_')]
           : undefined;
         if (value === undefined) continue;
-        // Skip if any variant of the flag is already in CLI args
-        if (flags.some(f => originalArgs.includes(f))) continue;
+        // Skip if any variant of the flag is already in CLI args. Exact-token
+        // match: `originalArgs.includes('--dns')` also matched inside
+        // `--dns-cache`, so a config's `dns` was silently dropped when
+        // `--dns-cache` was on the CLI. Split the snapshot into tokens instead.
+        const originalTokens = originalArgs.split(/\s+/);
+        if (flags.some(f => originalTokens.includes(f))) continue;
 
         if (typeof value === 'boolean') {
           if (value) args.push(flags[flags.length - 1]);
@@ -1208,7 +1212,10 @@ function getCompiledRegex(pattern) {
   let compiled = _compiledRegexCache.get(pattern);
   if (!compiled) {
     compiled = new RegExp(pattern.replace(/^\/(.*)\/$/, '$1'));
-    if (_compiledRegexCache.size > 2000) _compiledRegexCache.clear();
+    // Evict the single oldest entry (Map preserves insertion order → FIFO)
+    // instead of .clear() — a full wipe at 2000 forces every live pattern to
+    // recompile at once (cache stampede).
+    if (_compiledRegexCache.size > 2000) _compiledRegexCache.delete(_compiledRegexCache.keys().next().value);
     _compiledRegexCache.set(pattern, compiled);
   }
   return compiled;
@@ -6533,15 +6540,14 @@ function setupFrameHandling(page, forceDebug) {
   // === POST-SCAN PROCESSING ===
   // Clean up first-party domains and validate results
   if (!dryRunMode) {
-    // Always run post-processing for both firstParty cleanup and ignoreDomains safety net
+    // Run post-processing ALWAYS (not only when a site has firstParty:false) —
+    // it also applies the ignoreDomains safety net + dedup, which a config with
+    // no firstParty:false sites still needs. Guarding it skipped that sweep.
     const sitesWithFirstPartyDisabled = sites.filter(site => site.firstParty === false);
-    if (sitesWithFirstPartyDisabled.length > 0) {
-      if (forceDebug) {
-        console.log(formatLogMessage('debug', `Running post-scan processing for ${sitesWithFirstPartyDisabled.length} sites with firstParty: false`));
-      }
-    // Always run post-processing for ignoreDomains safety net
-    results = processResults(results, sites, { forceDebug, silentMode, ignoreDomains });
+    if (forceDebug && sitesWithFirstPartyDisabled.length > 0) {
+      console.log(formatLogMessage('debug', `Running post-scan processing for ${sitesWithFirstPartyDisabled.length} sites with firstParty: false`));
     }
+    results = processResults(results, sites, { forceDebug, silentMode, ignoreDomains });
   }
 
   // Handle dry run output file writing
@@ -6748,7 +6754,6 @@ function setupFrameHandling(page, forceDebug) {
         if (!silentMode) {
           // Report compression results and file sizes
           results.successful.forEach(({ original, compressed }) => {
-            const originalSize = fs.statSync(compressed).size; // compressed file size
             console.log(messageColors.success('✅ Compressed:') + ` ${path.basename(original)} → ${path.basename(compressed)}`);
           });
           // Report any compression failures


### PR DESCRIPTION
Cherry-picked and **reimplemented against current `main`** the verified-safe fixes from a review of `b4lol/network-scanner@4a76167` (a bulk AI-fix commit against a month-old tree). Each change was re-checked for correctness and applicability; the risky/superseded/no-op ones were deliberately dropped.

## Included

**Security**
- **`openvpn_vpn.js`**: allowlist `extra_args` against root-code-exec directives (`--script-security`/`--up`/`--down`/`--plugin`/…) — openvpn runs under `sudo`; constrain `connectionName` in the `pkill -f` regex; log file `0o666 → 0o600`; validate `verbosity` as a digit `1-6`; restrict `auth_file` to the project dir or system temp (blocks `/etc/shadow` reads). *(Guards `extra_args` only — a hostile `.ovpn` file can still carry these directives, so trust the config source.)*
- **`curl.js`/`grep.js`**: `--proto-redir =http,https` (blocks redirect hops to `file://`/`gopher://`/…); `curl.js` drops CR/LF-bearing custom headers (header injection).
- **`smart-cache.js`**: pid-suffixed temp path + `0o600` cache write.

**Leak**
- **`cloudflare.js`**: capture-and-clear the 5 `Promise.race` timeout timers in `.finally()` (they leaked on the fast path). Same pattern already in `interaction.js`/`cdp.js`.

**Bugs / perf**
- **`nwss.js`**: `.nwssconfig` flag match by exact token (was `includes()` — `--dns` matched inside `--dns-cache`, silently dropping a config's resolvers); `_compiledRegexCache` FIFO eviction instead of `.clear()` stampede; run `processResults` always (ignoreDomains safety-net was skipped for configs with no `firstParty:false` site); drop a dead `fs.statSync`.
- **`redirect.js`**: parallel `Set` for O(1) redirect-chain dedup.
- **`interaction.js`**: guard random coords against a sub-margin viewport.
- **`ignore_similar.js`**: null-guard before `Array.from` (the old "handles undefined safely" comment was wrong).
- **`searchstring.js`**: precompiled `^`-anchored content-type regex (verified equivalent to the old `startsWith` scan).

## Deliberately skipped
- `compare.js` combined regex — **not equivalent** to the sequential replaces (`^`-anchored alts only fire at pos 0; proven divergence on `||0.0.0.0 x`).
- `--noproxy <private ranges>` — misdescribed; it *bypasses* the proxy rather than blocking SSRF. (`--proto-redir` kept.)
- `ghost-cursor.js` `.page` — already handled in current code.
- `nettools.js` execSync→spawnSync probes — current code is more advanced (platform-aware `which`/`where`).
- `browserexit.js` allSettled — current code already wraps `page.close()` in try/catch, so `Promise.all` can't reject; nothing to fix.
- `referrer.js` recursion cap — `mixed` mode never recurses to `mixed`; no-op.
- `fingerprint.js` canvas regex — low value, file diverged (Chrome-150 grease).

## Verification
- `node --check` on all 10 files + `npm run lint` clean.
- Functional tests pass: searchstring regex equivalence (8 content types), openvpn verbosity validation + auth_file path restriction (cwd/tmp allowed, `/etc/hostname` rejected), interaction viewport guard, ignore_similar null guard, `.nwssconfig` exact-token match, cloudflare 5/5 timers captured, redirect push/add balanced.
- Entry smoke: `--help` + `--validate-config` OK.